### PR TITLE
Register own npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ feedMeta: {
 }
 ```
 
-### `serializeFeed` (optional
+### `serializeFeed` (optional)
 
-Include this if you want to create JSON feed files. If you want to create multiple types of feed files, add multiple `gatsby-plugin-json-output-multi-feed` objects to `gatsby-config.js`, name each feed in its `serializeFeed` function using the `feedName` field.
+Include this if you want to create JSON feed files. If you want to create multiple types of feed files, add multiple `gatsby-plugin-json-output-multi-feed` objects to `gatsby-config.js`, specify a name using the `feedName` field. This is useful if you want to provide feeds with different kinds of content / data.
 
 This plugin uses this serializeFeed function to structure the contents of the JSON feed files. You can use this function to restructure the nested nature of `graphQLQuery`. This plugin will pass the results object of the `graphQLQuery` to your `serializeFeed` function.
 
@@ -229,6 +229,12 @@ You will find the feed files in the built assets starting from `public/feed-1.js
 
 This is an optional number (integer) of nodes to include per feed file. Defaults to 100.
 
+### `feedName` (optional)
+
+Default naming is `feed` followed by the pagination. Example: `feed-1.json`.
+
+Use this option to set the name of the feed file. This is useful if you want to create multiple feed files for different kinds of content / structure.
+
 ## Uninstall
 
 Remove the config from your `gatsby-config.js`, then:
@@ -236,11 +242,11 @@ Remove the config from your `gatsby-config.js`, then:
 With NPM:
 
 ```bash
-npm uninstall gatsby-plugin-json-output
+npm uninstall gatsby-plugin-json-output-multi-feed
 ```
 
 With Yarn:
 
 ```bash
-yarn remove gatsby-plugin-json-output
+yarn remove gatsby-plugin-json-output-multi-feed
 ```

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Fetch JSON content from Gatsby with API-like static feeds that automatically upd
 With NPM:
 
 ```bash
-npm install gatsby-plugin-json-output
+npm install gatsby-plugin-json-output-multi-feed
 ```
 
 With Yarn:
 
 ```bash
-yarn add gatsby-plugin-json-output
+yarn add gatsby-plugin-json-output-multi-feed
 ```
 
 ## Usage
@@ -79,6 +79,7 @@ plugins: [
         excerpt: node.excerpt,
       })),
       nodesPerFeedFile: 100,
+      feedName: 'customFeedName',
     }
   }
 ];
@@ -174,7 +175,7 @@ feedMeta: {
 
 ### `serializeFeed` (optional
 
-Include this if you want to create JSON feed files.
+Include this if you want to create JSON feed files. If you want to create multiple types of feed files, add multiple `gatsby-plugin-json-output-multi-feed` objects to `gatsby-config.js`, name each feed in its `serializeFeed` function using the `feedName` field.
 
 This plugin uses this serializeFeed function to structure the contents of the JSON feed files. You can use this function to restructure the nested nature of `graphQLQuery`. This plugin will pass the results object of the `graphQLQuery` to your `serializeFeed` function.
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "gatsby-plugin-json-output",
-  "version": "1.1.3",
+  "name": "gatsby-plugin-json-output-multi-feed",
+  "version": "1.1.4",
   "description": "Fetch JSON content from Gatsby with API-like static feeds that automatically update with your builds.",
   "main": "index.js",
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dominicfallows/gatsby-plugin-json-output.git"
+    "url": "git+https://github.com/roadlittledawn/gatsby-plugin-json-output.git"
   },
-  "author": "Dominic Fallows <consultant@dominicfallows.uk>",
+  "author": "Clinton Langosch <clinton.langosch@gmail.com>",
   "license": "MIT",
   "keywords": [
     "gatsby",
@@ -16,9 +16,9 @@
     "json"
   ],
   "bugs": {
-    "url": "https://github.com/dominicfallows/gatsby-plugin-json-output/issues"
+    "url": "https://github.com/roadlittledawn/gatsby-plugin-json-output/issues"
   },
-  "homepage": "https://github.com/dominicfallows/gatsby-plugin-json-output",
+  "homepage": "https://github.com/roadlittledawn/gatsby-plugin-json-output",
   "files": [
     "/lib",
     "gatsby-node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-json-output-multi-feed",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Fetch JSON content from Gatsby with API-like static feeds that automatically update with your builds.",
   "main": "index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
For time being published separate npm package and using that. merging to master so everything is up to date. 